### PR TITLE
Give Null a meaningful inspect method

### DIFF
--- a/lib/nullobject.rb
+++ b/lib/nullobject.rb
@@ -12,6 +12,10 @@ module Null
   def to_i; 0; end
   def nil?; true; end
 
+  def inspect
+    "#<%s:0x%x>" % [self.class, object_id]
+  end
+
   def method_missing(*args, &block)
     self
   end

--- a/spec/lib/nullobject_spec.rb
+++ b/spec/lib/nullobject_spec.rb
@@ -26,6 +26,10 @@ describe "Null::Object" do
     it "#nil? return true" do
       @it.nil?.must_equal true
     end
+
+    it "#inspect is meaningful" do
+      @it.inspect.wont_be_empty
+    end
   end
 
   describe "custom null" do


### PR DESCRIPTION
Hi Marcin,

First - thanks for throwing this gem together. Having this gem makes it a lot easier to put the ideas from Avdi's talk and the Null Object pattern into practice.

I added the inspect method to make debugging better. Inspecting an object and seeing nothing at all makes it very unclear what's going on, especially to other developers who aren't familiar with the how Null objects act.

```
1.9.3p125 :001 > require './lib/nullobject'
 => true
1.9.3p125 :002 > Null::Object.instance
 => #<Null::Object:0x8089d624>
```

This is also consistent with Avdi's slides. 
http://avdi.org/talks/confident-code-rubymidwest-2011/confident-code.html#slide41
