### PR TITLE
Should respond to #to_ary

### DIFF
--- a/lib/nullobject.rb
+++ b/lib/nullobject.rb
@@ -7,6 +7,7 @@ module Null
   end
 
   def to_a; []; end
+  def to_ary; []; end
   def to_s; ""; end
   def to_f; 0.0; end
   def to_i; 0; end

--- a/spec/lib/nullobject_spec.rb
+++ b/spec/lib/nullobject_spec.rb
@@ -15,6 +15,10 @@ describe "Null::Object" do
       @it.to_a.must_equal []
     end
 
+    it "#to_ary return empty array" do
+      @it.to_ary.must_equal []
+    end
+
     it "#to_f return 0.0" do
       @it.to_f.must_equal 0.0
     end


### PR DESCRIPTION
Figured since `#to_a` is explicitly defined to return `[]` that `#to_ary` should also be defined, returning `[]` too.
