### PR TITLE
Adding support for to_s with params

### DIFF
--- a/lib/nullobject.rb
+++ b/lib/nullobject.rb
@@ -8,7 +8,7 @@ module Null
 
   def to_a; []; end
   def to_ary; []; end
-  def to_s; ""; end
+  def to_s(*p); ""; end
   def to_f; 0.0; end
   def to_i; 0; end
   def nil?; true; end

--- a/spec/lib/nullobject_spec.rb
+++ b/spec/lib/nullobject_spec.rb
@@ -11,6 +11,10 @@ describe "Null::Object" do
       @it.to_s.must_equal ""
     end
 
+    it "#to_s(:param) return empty string" do
+      @it.to_s(:param).must_equal ""
+    end
+
     it "#to_a return empty array" do
       @it.to_a.must_equal []
     end
@@ -59,6 +63,10 @@ describe "Null::Object" do
 
     it "#to_s return empty string" do
       @it.to_s.must_equal ""
+    end
+
+    it "#to_s(:param) return empty string" do
+      @it.to_s(:param).must_equal ""
     end
 
     it "#to_a return empty array" do


### PR DESCRIPTION
Trying to fix this:

```ruby
#Before
FooNullObject.date.to_s(:us_date)
ArgumentError: wrong number of arguments (1 for 0)
...

#After
FooNullObject.date.to_s(:us_date) 
""

```